### PR TITLE
fix: Correctly parse GTS if it contains NaN

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^.lintr$
 ^.pre-commit-config.yaml$
 ^LICENSE\.md$
+^.vscode

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: warp10r
 Title: R Client for executing WarpScript on a Warp 10 instance
-Version: 0.19.6
+Version: 0.19.7
 Authors@R: 
     c(person(given = "Jean-Charles",
              family = "Vialatte",

--- a/R/bind_gts.R
+++ b/R/bind_gts.R
@@ -79,8 +79,12 @@ build_gts_value <- function(data) {
   }
   tibble::as_tibble(
     stats::setNames(
-      object = lapply(seq_len(n), function(i) sapply(l, `[[`, i)),
-      nm = colnames
+    object = lapply(seq_len(n), function(i) {
+      sapply(l, function(x) {
+        ifelse(is.null(x[[i]]), NA, x[[i]])
+      })
+    }),
+    nm = colnames
     )
   )
 }

--- a/tests/testthat/test-gts.R
+++ b/tests/testthat/test-gts.R
@@ -49,6 +49,21 @@ test_that("possibility to create and retrieve GTS with some values", {
   expect_equal(as.data.frame(gts2), as.data.frame(as_gts(df2)))
 })
 
+test_that("retrieve a GTS with some NaN values", {
+  con <- wrp_connect()
+  df  <- tibble::tibble(
+    timestamp = c(1, 2),
+    value     = c(1.1, NA)
+  )
+  gts <- con %>%
+    wrp_new_gts() %>%
+    wrp_add_value_df(df, tick = "timestamp") %>%
+    wrp_exec()
+  # NaN not supported for LONG value in warpscript
+  # Could not expect_identical with FLOAT value
+  expect_equal(gts, as_gts(df))
+})
+
 test_that("bucketize works as expected", {
   con  <- wrp_connect()
   n    <- 4


### PR DESCRIPTION
NaN is not recognize as a json object which is turned into a NULL object.
But to transform a gts into a dataframe, if values have some NULL values, then the end result would be that the value column would have a list of list instead of list of double/long/...
To take that into account, transform NULL to NA before the transformation.
